### PR TITLE
add skipWaiting call

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ writeServiceWorker(completeTree, {
   ],
   dynamicCache: [
     '/api/todos'
-  ]
+  ],
+  skipWaiting: true
 });
 ```
 

--- a/lib/service-worker.js
+++ b/lib/service-worker.js
@@ -12,6 +12,7 @@ var BroccoliServiceWorker = function BroccoliServiceWorker(inTree, options) {
   this.inTree = inTree;
   options = options || {};
   this.addPolyfill = options.addPolyfill || true;
+  this.skipWaiting = options.skipWaiting || false;
   this.debug = options.debug || true;
   this.dynamicCache = options.dynamicCache || [];
   this.excludePaths = options.excludePaths || ['tests/*'];
@@ -26,6 +27,7 @@ BroccoliServiceWorker.prototype.constructor = BroccoliServiceWorker;
 
 BroccoliServiceWorker.prototype.write = function(readTree, destDir) {
   var addPolyfill = this.addPolyfill;
+  var skipWaiting = this.skipWaiting;
   var debug = this.debug;
   var dynamicCache = this.dynamicCache;
   var fallback = this.fallback;
@@ -77,7 +79,7 @@ BroccoliServiceWorker.prototype.write = function(readTree, destDir) {
 
       if (!stat.isFile() && !stat.isSymbolicLink())
         return;
-      lines.push(createArrayLine("'"+file+"'", idx, array.length));
+      lines.push(createArrayLine("    '"+file+"'", idx, array.length));
     });
     lines.push("];");
 
@@ -87,6 +89,11 @@ BroccoliServiceWorker.prototype.write = function(readTree, destDir) {
 
     //ServiceWorker code derived from examples at https://github.com/GoogleChrome/samples/tree/gh-pages/service-worker
     addDebugLine("'Handling install event. Resources to pre-fetch:', urlsToPrefetch", debug, lines);
+
+    if (skipWaiting) {
+      lines.push("  if (self.skipWaiting) { self.skipWaiting(); }");
+    }
+
     lines.push("  event.waitUntil(");
     lines.push("    caches.open(CURRENT_CACHES['prefetch']).then(function(cache) {");
     lines.push("      return cache.addAll(urlsToPrefetch.map(function(urlToPrefetch) {");


### PR DESCRIPTION
This is a very useful method that allows the service worker to skip the waiting state and go directly to the activated state. This allows a simple page refresh to update the app.

Sources:
- https://github.com/jakearchibald/simple-serviceworker-tutorial#4-faster-updates
- http://stackoverflow.com/questions/28069249/how-to-stop-older-service-workers
