### PR TITLE
Clean content-for method

### DIFF
--- a/lib/ember-addon.js
+++ b/lib/ember-addon.js
@@ -2,6 +2,7 @@ var path = require('path');
 var fs   = require('fs');
 var mergeTrees = require('broccoli-merge-trees');
 var funnel = require('broccoli-funnel');
+var stringifile = require('stringifile');
 
 var serviceWorker = require('./service-worker.js');
 
@@ -48,18 +49,7 @@ module.exports = {
 
   contentFor: function(type, config) {
     if (config.environment !== 'test' && type === 'body-footer') {
-      var lines = [];
-      lines.push('<script>');
-      lines.push('if (\'serviceWorker\' in navigator) {');
-      lines.push('  navigator.serviceWorker.register(\'./service-worker.js\', {scope: \'./\'})');
-      lines.push('    .catch(function(error) {');
-      lines.push('      alert(\'Error registering service worker:\'+error);');
-      lines.push('    });');
-      lines.push('} else {');
-      lines.push('  alert(\'service worker not supported\');');
-      lines.push('}');
-      lines.push('</script>');
-      return lines.join('\n');
+      return stringifile('registration.js', 'script', __dirname);
     }
   }
 };

--- a/lib/registration.js
+++ b/lib/registration.js
@@ -1,0 +1,8 @@
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('./service-worker.js', {scope: './'})
+    .catch(function(error) {
+      alert('Error registering service worker:'+error);
+    });
+} else {
+  alert('service worker not supported');
+}

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "broccoli-merge-trees": "~0.1.4",
     "broccoli-writer": "~0.1.1",
     "serviceworker-cache-polyfill": "^3.0.0"
+  },
+  "devDependencies": {
+    "stringifile": "^0.1.1"
   }
 }


### PR DESCRIPTION
Move ServiceWorker registration to another file in order to make it more readable and clean the `content-for` method /cc @miguelcobain 
