### PR TITLE
Escape the filename in the array of files.

### DIFF
--- a/lib/service-worker.js
+++ b/lib/service-worker.js
@@ -66,7 +66,7 @@ BroccoliServiceWorker.prototype.write = function(readTree, destDir) {
 
       if (!stat.isFile() && !stat.isSymbolicLink())
         return;
-      lines.push(createArrayLine("    '"+file+"'", idx, array.length));
+      lines.push(createArrayLine('    '+JSON.stringify(file), idx, array.length));
     });
     lines.push("];");
     precacheURLs.forEach(function (file, idx, array) {


### PR DESCRIPTION
Currently, if your filename contains a `'`, it breaks the implementation. This should fix that.
