### PR TITLE
fallback request with navigate mode fix

### DIFF
--- a/lib/fallback-response.js
+++ b/lib/fallback-response.js
@@ -1,12 +1,31 @@
 function getFallbackFromCache(request, values, options) {
   logDebug('Fetching from fallback url: '+ options.fallbackURL +'for url: '+request.url);
-  var req = new Request(options.fallbackURL, request);
-  return toolbox.cacheFirst(req, values, options).then(function(response) {
-    if (response) {
-      logDebug('Got fallback response from cache',response);
-      return response;
-    }
-  });
+  return request
+    .text()
+    .then(function(text) {
+      // cannot set mode to navigate in Request constructor init object
+      // https://fetch.spec.whatwg.org/#dom-request
+      var mode = request.mode === 'navigate' ? 'same-origin' : request.mode;
+      var body = text === '' ? undefined : text;
+      return new Request(options.fallbackURL, {
+        method: request.method,
+        headers: request.headers,
+        body: body,
+        mode: mode,
+        credentials: request.credentials,
+        redirect: request.redirect,
+        cache: request.cache,
+      });
+    })
+    .then(function(req) {
+      return toolbox.cacheFirst(req, values, options);
+    })
+    .then(function(response) {
+      if (response) {
+        logDebug('Got fallback response from cache',response);
+        return response;
+      }
+    });
 }
 
 function fallbackResponse(request, values, options) {


### PR DESCRIPTION
I was having an error "Cannot construct a Request with a Request whose mode is 'navigate' and a non-empty RequestInit." when using fallback feature. Look [here](https://fetch.spec.whatwg.org/#dom-request) at the documentation of `Request` constructor.  It is written: "If mode is "navigate", throw a TypeError.".
