### PR TITLE
Add rootURL option

### DIFF
--- a/lib/ember-addon.js
+++ b/lib/ember-addon.js
@@ -38,7 +38,8 @@ module.exports = {
     var defaultOptions = {
       enabled: this.app.env === 'production',
       excludePaths: ['test.*','robots.txt'],
-      precacheURLs: []
+      precacheURLs: [],
+      rootURL: appOptions.rootURL || appOptions.baseURL
     };
 
     for (var option in defaultOptions) {

--- a/lib/service-worker.js
+++ b/lib/service-worker.js
@@ -25,6 +25,7 @@ var BroccoliServiceWorker = function BroccoliServiceWorker(inTree, options) {
   this.networkFirstURLs = options.networkFirstURLs || options.dynamicCache || [];
   this.excludePaths = options.excludePaths || ['tests/*'];
   this.fallback = options.fallback || [];
+  this.rootURL = options.rootURL || '/';
   this.precacheURLs = options.precacheURLs || [];
   if (options.includeRegistration === false) {
     this.includeRegistration = false;
@@ -50,6 +51,7 @@ BroccoliServiceWorker.prototype.write = function(readTree, destDir) {
   var debug = this.debug;
   var networkFirstURLs = this.networkFirstURLs;
   var fallback = this.fallback;
+  var rootURL = this.rootURL;
   var fastestURLs = this.fastestURLs;
   var precacheURLs = this.precacheURLs;
   var serviceWorkerFile = this.serviceWorkerFile;
@@ -70,7 +72,7 @@ BroccoliServiceWorker.prototype.write = function(readTree, destDir) {
         lines.push("toolbox.options.debug = true;");
       }
       lines.push("var urlsToPrefetch = [");
-      lines.push("    '/',");
+      lines.push("    '"+rootURL+"',");
       getFilesRecursively(srcDir, [ "**/*" ]).forEach(function (file, idx, array) {
         lines.push(createArrayLine('    '+JSON.stringify(file), idx, array.length));
       });


### PR DESCRIPTION
Hi,
I've noticed that '/' URL is prefetched by default, and there is no way to affect this from configuration.
This will break the service worker if the application is hosted on a non-root URL, and root URL is unavailable for some reason.

This PR adds a rootURL option, which defaults to rootURL or baseURL when used in form of Ember addon, and to '/' when used directly.
