### PR TITLE
fix: use absolute path instead of relative path

### DIFF
--- a/lib/registration.js
+++ b/lib/registration.js
@@ -1,5 +1,5 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('./service-worker.js', {scope: './'})
+  navigator.serviceWorker.register('/service-worker.js', {scope: '/'})
     .catch(function(error) {
       console.error('Error registering service worker:'+error);
     });


### PR DESCRIPTION
We're using this addon for our ember service worker and it works quite nice so far. Thanks! :)

Little thing we noticed: If you go straight to a subroute (let's say `/authenticate/123456`) you'll see this in your console:

<img width="950" alt="coach" src="https://cloud.githubusercontent.com/assets/82050/17439570/05a0280c-5b29-11e6-8ce1-9b99cd581ec5.png">

With this PR the URL is just the root URL and absolute and the service worker installs as needed. Does this make sense?
