### PR TITLE
Upgrade sw-toolbox to version 3.4.0

### DIFF
--- a/lib/service-worker.js
+++ b/lib/service-worker.js
@@ -4,7 +4,7 @@ var brocWriter = require("broccoli-writer");
 var helpers = require("broccoli-kitchen-sink-helpers");
 var funnel = require('broccoli-funnel');
 var swToolboxFile = require.resolve('sw-toolbox/sw-toolbox.js');
-var swToolboxMapFile = require.resolve('sw-toolbox/sw-toolbox.map.json');
+var swToolboxMapFile = require.resolve('sw-toolbox/sw-toolbox.js.map');
 var toolboxLocation = 'sw-toolbox.js';
 var rsvp= require('rsvp');
 var BroccoliServiceWorker = function BroccoliServiceWorker(inTree, options) {
@@ -131,7 +131,7 @@ BroccoliServiceWorker.prototype.write = function(readTree, destDir) {
       fs.writeFileSync(path.join(destDir, serviceWorkerFile), lines.join("\n"));
       fs.writeFileSync(path.join(destDir, toolboxLocation), fs.readFileSync(swToolboxFile));
       if (debug) {
-        fs.writeFileSync(path.join(destDir, 'sw-toolbox.map.json'), fs.readFileSync(swToolboxMapFile));
+        fs.writeFileSync(path.join(destDir, 'sw-toolbox.js.map'), fs.readFileSync(swToolboxMapFile));
       }
     });
   });

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "broccoli-writer": "~0.1.1",
     "rsvp": "^3.1.0",
     "stringifile": "^0.1.1",
-    "sw-toolbox": "^3.1.1"
+    "sw-toolbox": "^3.4.0"
   }
 }


### PR DESCRIPTION
A clean install of `broccoli-serviceworker` would install the latest `sw-toolbox`. However, the name of `sw-toolbox`'s source map file has changed, which would break the installation of `broccoli-serviceworker`.
