### PR TITLE
Implemented a cache post-delete hook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ The following options allow you to specify routes that use [sw-toolbox's built-i
   * **method** - the HTTP method for the route.  Defaults to **any** which matches all HTTP methods.
   * **options** - passed to the [route handler](https://github.com/GoogleChrome/sw-toolbox#methods) and are available for example to specify a different origin domain.
 
+####Hooks
+The following hooks are available to your service worker code. Implement a hook by defining a `function` by the hook's name and it will be called.
+
+* `brocswPostDeleteCacheHook(cacheName)` -- When a new version of the service worker is loaded, old caches are automatically deleted. This hook is called for each stale cache right after it has been deleted. This hook must return a `Promise`.
+
 Usage for Broccoli.js
 ---------------------
 

--- a/lib/delete-old-caches.js
+++ b/lib/delete-old-caches.js
@@ -21,16 +21,11 @@ self.addEventListener('activate', function(event) {
 });
 
 function _postDeleteCacheHook(cacheName) {
-  try {
+  if (typeof brocswPostDeleteCacheHook === 'function') {
     return brocswPostDeleteCacheHook(cacheName);
   }
-  catch (e) {
-    if (e instanceof ReferenceError) {
-      // Hook is not implemented in the app's serviceworker, that's fine.
-      return Promise.resolve();
-    }
-    else {
-      return Promise.reject(e);
-    }
+  else {
+    // Hook is not implemented in the app's serviceworker, that's fine.
+    return Promise.resolve();
   }
 }

--- a/lib/delete-old-caches.js
+++ b/lib/delete-old-caches.js
@@ -22,7 +22,7 @@ self.addEventListener('activate', function(event) {
 
 function _postDeleteCacheHook(cacheName) {
   try {
-    brocswPostDeleteCacheHook(cacheName);
+    return brocswPostDeleteCacheHook(cacheName);
   }
   catch (e) {
     if (e instanceof ReferenceError) {

--- a/lib/delete-old-caches.js
+++ b/lib/delete-old-caches.js
@@ -9,7 +9,9 @@ self.addEventListener('activate', function(event) {
           return (cacheName.indexOf('$$$inactive$$$') === -1 && cacheName.indexOf(CACHE_PREFIX) === 0 && cacheName !== CACHE_VERSION);
         }).map(function(cacheName) {
           logDebug('Deleting out of date cache:', cacheName);
-          return caches.delete(cacheName);
+          return caches.delete(cacheName).then(function() {
+            return _postDeleteCacheHook(cacheName);
+          });
         })
       );
     }).then(function() {
@@ -17,3 +19,18 @@ self.addEventListener('activate', function(event) {
     })
   );
 });
+
+function _postDeleteCacheHook(cacheName) {
+  try {
+    brocswPostDeleteCacheHook(cacheName);
+  }
+  catch (e) {
+    if (e instanceof ReferenceError) {
+      // Hook is not implemented in the app's serviceworker, that's fine.
+      return Promise.resolve();
+    }
+    else {
+      return Promise.reject(e);
+    }
+  }
+}


### PR DESCRIPTION
My use case is:

My service worker creates an IndexedDB database to store some offline data. The database name corresponds to the cache name, so that it can leverage the `CACHE_VERSION` versioning mechanism and start fresh when the service worker code changes.

I needed a way to delete stale databases just like old caches are deleted in the `activate` event handled by `delete-old-caches.js`. I figured that a hook would be appropriate, where the service worker code simply needs to define a specific function name to enable the hook.
