### PR TITLE
Origin option can be regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following options allow you to specify routes that use [sw-toolbox's built-i
   ```
   * **route** - the url or regular expression for the route.
   * **method** - the HTTP method for the route.  Defaults to **any** which matches all HTTP methods.
-  * **options** - passed to the [route handler](https://github.com/GoogleChrome/sw-toolbox#methods) and are available for example to specify a different origin domain.
+  * **options** - passed to the [route handler](https://github.com/GoogleChrome/sw-toolbox#methods) and are available for example to specify a different origin domain (can use regular expression).
 
 ####Hooks
 The following hooks are available to your service worker code. Implement a hook by defining a `function` by the hook's name and it will be called.

--- a/lib/service-worker.js
+++ b/lib/service-worker.js
@@ -188,8 +188,13 @@ function setupRoutes(routeUrls, handler, lines) {
     routeUrls.forEach(function(cacheURL, idx, array) {
       var method = 'any';
       var options;
+      var origin;
 
       if (typeof cacheURL === 'object' && (cacheURL instanceof RegExp === false)) {
+        origin = cacheURL.options && cacheURL.options.origin;
+        if (origin) {
+          cacheURL.options.origin = '[origin]';
+        }
         options = JSON.stringify(cacheURL.options);
         if (cacheURL.method) {
           method = cacheURL.method;
@@ -201,6 +206,10 @@ function setupRoutes(routeUrls, handler, lines) {
       if (options) {
         line += ', ';
         line += options;
+      }
+
+      if (origin) {
+        line = line.replace('"[origin]"', printPath(origin));
       }
 
       line += ');';


### PR DESCRIPTION
To enable use of regular expressions in origin options, modify `setupRoutes()` to use temporary placeholder that is replaced with `printPath()` parsed origin.

> - `options` - an object containing options for the route. This options object will be passed to the request handler. The `origin` option is specific to the router methods, and can be either an exact string or **a Regexp against which the origin** of the Request must match for the route to be used.

https://github.com/GoogleChrome/sw-toolbox/blob/master/docs/api.md#methods

**Example Usage**

```javascript
ENV.serviceWorker = {
  networkFirstURLs: [
    { route: '/(.*)', method: 'get', options: { origin: new RegExp(/myapihost/) } }
  ]
};
```